### PR TITLE
Add timeout tolerances for apply/run respectively

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Atlantis Automation'
 description: 'Checks for result of atlantis plan, approves PR, and runs atlantis apply'
 
 inputs:
-  pr_number: 
+  pr_number:
     description: 'PR number'
     required: true
   github_token:

--- a/main.go
+++ b/main.go
@@ -159,8 +159,8 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				td = int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
 				fmt.Printf("Looking for [%s] elapsed (since start)[%.3fs] -- (since last check)[%.3fs]\n", match, currentElapsedTime.Seconds(), elapsedTime.Seconds())
 
-				fmt.Printf("td [%d] <= acceptableTimeDelta[%d] -  %s", td, acceptableTimeDelta, (td <= acceptableTimeDelta))
-				fmt.Printf("match [%s] with bodyContent -  %s", match, strings.Contains(bodyContent, match))
+				fmt.Printf("td [%d] <= acceptableTimeDelta[%d] -  %v\n", td, acceptableTimeDelta, (td <= acceptableTimeDelta))
+				fmt.Printf("match [%s] with bodyContent -  %v\n", match, strings.Contains(bodyContent, match))
 
 				if strings.Contains(bodyContent, match) && td <= acceptableTimeDelta {
 					fmt.Printf("Result found for [%s] user: [%s] PR created [%s] comment created [%s] time delta [%d]\n", match, *user.Login, prCreatedTs, comment.GetCreatedAt(), td)
@@ -169,6 +169,8 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 					errMsg := fmt.Sprintf("Took longer than [%ds] to find comment [%s]. PR created [%s] plan created [%s]", td, match, prCreatedTs, commentCreated)
 					return nil, errors.New(errMsg)
 				}
+
+				fmt.Printf("no match, match [%s] against body:[%s]\n", match, bodyContent)
 			}
 			// otherwise skip the PR message
 			fmt.Printf("Skipping comment [%s] time delta[%ds] user [%s] comment created at [%s] PR created at [%s]\n", match, td, *user.Login, comment.GetCreatedAt(), prCreatedTs)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ const (
 	 * comments from Atlantis __can__ exist, but we only care about the most
 	 * recent one.
 	 */
-	acceptablePlanElapsedTolerance = 65 //seconds
+	acceptablePlanElapsedTolerance  = 65   //seconds
 	acceptableApplyElapsedTolerance = 1500 //seconds
 	planComment                     = "Ran Plan for dir"
 	planError                       = "Plan Error"
@@ -255,7 +255,6 @@ func runApply(org string, repo string, prNum int, atlantisPath string) {
 	fmt.Println(fmt.Sprintf("Commented `%s`", comment))
 	fmt.Println("Waiting for apply to start...")
 }
-
 
 /* Obligatory mainly main entry point */
 func main() {

--- a/main.go
+++ b/main.go
@@ -159,8 +159,8 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				td = int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
 				fmt.Printf("Looking for [%s] elapsed (since start)[%.3fs] -- (since last check)[%.3fs]\n", match, currentElapsedTime.Seconds(), elapsedTime.Seconds())
 
-				fmt.printf("td [%d] <= acceptableTimeDelta[%d] -  %s", td, acceptableTimeDelta, (td <= acceptableTimeDelta))
-				fmt.printf("match [%s] with bodyContent -  %s", match, strings.Contains(bodyContent, match))
+				fmt.Printf("td [%d] <= acceptableTimeDelta[%d] -  %s", td, acceptableTimeDelta, (td <= acceptableTimeDelta))
+				fmt.Printf("match [%s] with bodyContent -  %s", match, strings.Contains(bodyContent, match))
 
 				if strings.Contains(bodyContent, match) && td <= acceptableTimeDelta {
 					fmt.Printf("Result found for [%s] user: [%s] PR created [%s] comment created [%s] time delta [%d]\n", match, *user.Login, prCreatedTs, comment.GetCreatedAt(), td)

--- a/main.go
+++ b/main.go
@@ -157,6 +157,9 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				td = int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
 				fmt.Printf("Looking for [%s] elapsed (since start)[%.3fs] -- (since last check)[%.3fs]\n", match, currentElapsedTime.Seconds(), elapsedTime.Seconds())
 
+				fmt.printf("td [%d] <= acceptableTimeDelta[%d] -  %s", td, acceptableTimeDelta, (td <= acceptableTimeDelta))
+				fmt.printf("match [%s] with bodyContent -  %s", match, strings.Contains(bodyContent, match))
+
 				if strings.Contains(bodyContent, match) && td <= acceptableTimeDelta {
 					fmt.Printf("Result found for [%s] user: [%s] PR created [%s] comment created [%s] time delta [%d]\n", match, *user.Login, prCreatedTs, comment.GetCreatedAt(), td)
 					return comment, nil

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 	// callback to pass to the retry
 	commentSearch := func() (*github.IssueComment, error) {
 		// time tracking metric
+		var td int = 0
 		currentElapsedTime = exp.GetElapsedTime() * time.Nanosecond
 		elapsedTime = currentElapsedTime - oldElapsedTime
 		oldElapsedTime = currentElapsedTime
@@ -153,7 +154,7 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				 * Increasing the should probably be the last resort.
 				 */
 				commentCreated := comment.GetCreatedAt()
-				td := int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
+				td = int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
 				fmt.Printf("Looking for [%s] elapsed (since start)[%.3fs] -- (since last check)[%.3fs]\n", match, currentElapsedTime.Seconds(), elapsedTime.Seconds())
 
 				if strings.Contains(bodyContent, match) && td <= acceptableTimeDelta {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	timeOut             = 2 * time.Second
+	timeOut             = 20 * time.Second
 	initialInterval     = 800 * time.Millisecond
 	randomizationFactor = 0.5
 	multiplier          = 3
@@ -170,10 +170,10 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 					return nil, errors.New(errMsg)
 				}
 
-				fmt.Printf("no match, match [%s] against body:[%s]\n", match, bodyContent)
+				fmt.Printf("no match, match [%s] against body:[%s]\n", match, bodyContent[0:100])
 			}
 			// otherwise skip the PR message
-			fmt.Printf("Skipping comment [%s] time delta[%ds] user [%s] comment created at [%s] PR created at [%s]\n", match, td, *user.Login, comment.GetCreatedAt(), prCreatedTs)
+			//fmt.Printf("Skipping comment [%s] time delta[%ds] user [%s] comment created at [%s] PR created at [%s]\n", match, td, *user.Login, comment.GetCreatedAt(), prCreatedTs)
 		}
 		errMsg := fmt.Sprintf("Unexpected error - reached Timeout of ~ %.1f minutes.", maxElapsedTime.Minutes())
 		return nil, errors.New(errMsg)

--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 		oldElapsedTime = currentElapsedTime
 
 		prCreatedTs := getPrCreatedAt(ctx, client, org, repo, prNum)
+		fmt.Println("Getting list of comments.....")
 		comments, _, err := client.Issues.ListComments(ctx, org, repo, prNum, opt)
 		if err != nil {
 			fmt.Println(err)
@@ -159,7 +160,7 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				td = int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
 				fmt.Printf("Looking for [%s] elapsed (since start)[%.3fs] -- (since last check)[%.3fs]\n", match, currentElapsedTime.Seconds(), elapsedTime.Seconds())
 
-				fmt.Printf("td [%d] <= acceptableTimeDelta[%d] -  %v\n", td, acceptableTimeDelta, (td <= acceptableTimeDelta))
+				fmt.Printf("td [%d] <= acceptableTimeDelta[%d] -  %v - num comments[%d]\n", td, acceptableTimeDelta, (td <= acceptableTimeDelta), len(comments))
 				fmt.Printf("match [%s] with bodyContent -  %v\n", match, strings.Contains(bodyContent, match))
 
 				if strings.Contains(bodyContent, match) && td <= acceptableTimeDelta {

--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 			user := comment.GetUser()
 			if *user.Login == blinkGitHubUser {
 				bodyContent := comment.GetBody()
+				fmt.Printf("-> comment [%s]\n", bodyContent[0:100])
 
 				// quickly fail on error
 				if strings.Contains(bodyContent, errorMatch) {

--- a/main.go
+++ b/main.go
@@ -41,8 +41,7 @@ const (
 	 * recent one.
 	 */
 	acceptablePlanElapsedTolerance = 65 //seconds
-	//acceptableApplyElapsedTolerance = 1500 //seconds
-	acceptableApplyElapsedTolerance = 15 //seconds
+	acceptableApplyElapsedTolerance = 1500 //seconds
 	planComment                     = "Ran Plan for dir"
 	planError                       = "Plan Error"
 	applyComment                    = "Ran Apply for dir"

--- a/main.go
+++ b/main.go
@@ -1,11 +1,24 @@
 /*
-   This action looks for comments from Atlantis as atlantis emits plan.
-   Upon detecting a plan has been emitted, it will apply the plan.
+	This action searches for comments from Atlantis as it emits the plan.
+	Upon detecting a plan has been emitted, it will apply the plan.
 
-   To test locally:
-   export GITHUB_REPOSITORY="blinkhealth/$repo_name"
-   go mod init atlantis-gh-action
-   go build & ./atlantis-gh-action 22
+	The comment search is performed using exponential backoff and can be tuned
+	with the following constants:
+    - initialInterval, randomizationFactor, multiplier, maxInterval, maxElapsedTime
+	- more infor can be found in the `exponential.go`
+		- https://github.com/cenkalti/backoff/blob/a83af7fa09801a4a887cfe7c8472c12c76e8a468/exponential.go
+
+
+	To test locally and to exercise the comment search behavior:
+		- you will need an execution that has failed, where the  PR exists
+		- get the PR ID
+
+		- export GITHUB_REPOSITORY="blinkhealth/$repo_name"
+		- do this if you are adding more modules
+			- `go mod init atlantis-gh-action`
+	    - in main; comment out
+			- approvePr() and runApply()
+		- run `go build && ./atlantis-gh-action $PR_ID`
 */
 
 package main

--- a/main.go
+++ b/main.go
@@ -30,8 +30,10 @@ const (
 	randomizationFactor = 0.5
 	multiplier          = 3
 	// Lower maxInterval increases the retry frequency, scoped to maxElapsedTime
-	maxInterval     = 15 * time.Second
-	maxElapsedTime  = 20 * time.Minute
+	//maxInterval     = 10 * time.Second
+	//maxElapsedTime  = 15 * time.Minute
+	maxInterval     = 1 * time.Second
+	maxElapsedTime  = 7 * time.Minute
 	blinkGitHubUser = "blinkhealthgithub"
 
 	/* Time elapsed between pull request 'create time' and the time it took

--- a/main.go
+++ b/main.go
@@ -148,13 +148,14 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				}
 
 				/* Brute force ignore anything that takes longer.  If we fall
-								 * into this clause - figure out why it takes so long for
-								 * Atlantis to emit/apply a plan or increase the delta.
-								 * Increasing the should probably be the last resort.
-				*/
+				 * into this clause - figure out why it takes so long for
+				 * Atlantis to emit/apply a plan or increase the delta.
+				 * Increasing the should probably be the last resort.
+				 */
 				commentCreated := comment.GetCreatedAt()
 				td := int(prCreatedTs.Sub(*commentCreated.GetTime()).Abs().Seconds())
 				fmt.Printf("Looking for [%s] elapsed (since start)[%.3fs] -- (since last check)[%.3fs]\n", match, currentElapsedTime.Seconds(), elapsedTime.Seconds())
+
 				if strings.Contains(bodyContent, match) && td <= acceptableTimeDelta {
 					fmt.Printf("Result found for [%s] user: [%s] PR created [%s] comment created [%s] time delta [%d]\n", match, *user.Login, prCreatedTs, comment.GetCreatedAt(), td)
 					return comment, nil
@@ -164,7 +165,7 @@ func waitForComment(ctx context.Context, client github.Client, org string, repo 
 				}
 			}
 			// otherwise skip the PR message
-			fmt.Printf("Skipping: user: %s comment created at:[%s] pr created at:[%s]\n", *user.Login, comment.GetCreatedAt(), prCreatedTs)
+			fmt.Printf("Skipping comment [%s] time delta[%ds] user [%s] comment created at [%s] PR created at [%s]\n", match, td, *user.Login, comment.GetCreatedAt(), prCreatedTs)
 		}
 		errMsg := fmt.Sprintf("Unexpected error - reached Timeout of ~ %.1f minutes.", maxElapsedTime.Minutes())
 		return nil, errors.New(errMsg)

--- a/main.go
+++ b/main.go
@@ -1,23 +1,22 @@
 /*
-	This action searches for comments from Atlantis as it emits the plan.
-	Upon detecting a plan has been emitted, it will apply the plan.
+This action searches for comments from Atlantis as it emits the plan.
+Upon detecting a plan has been emitted, it will apply the plan.
 
-	The comment search is performed using exponential backoff and can be tuned
-	with the following constants:
+The comment search is performed using exponential backoff and can be tuned
+with the following constants:
 	- initialInterval, randomizationFactor, multiplier, maxInterval, maxElapsedTime
 	- more infor can be found in the `exponential.go`
 		- https://github.com/cenkalti/backoff/blob/a83af7fa09801a4a887cfe7c8472c12c76e8a468/exponential.go
 
+To test locally and to exercise the comment search behavior:
+	- you will need an execution that has failed, where the  PR exists
+	- get the PR ID
 
-	To test locally and to exercise the comment search behavior:
-		- you will need an execution that has failed, where the  PR exists
-		- get the PR ID
-
-		- export GITHUB_REPOSITORY="blinkhealth/$repo_name"
-		- do this if you are adding more modules
-			- `go mod init atlantis-gh-action`
-	    - in main; comment out
-			- approvePr() and runApply()
+	- export GITHUB_REPOSITORY="blinkhealth/$repo_name"
+	- do this if you are adding more modules
+		- `go mod init atlantis-gh-action`
+	- in main; comment out
+		- approvePr() and runApply()
 		- run `go build && ./atlantis-gh-action $PR_ID`
 */
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Upon detecting a plan has been emitted, it will apply the plan.
 The comment search is performed using exponential backoff and can be tuned
 with the following constants:
 	- initialInterval, randomizationFactor, multiplier, maxInterval, maxElapsedTime
-	- more infor can be found in the `exponential.go`
+	- See `exponential.go` for more info:
 		- https://github.com/cenkalti/backoff/blob/a83af7fa09801a4a887cfe7c8472c12c76e8a468/exponential.go
 
 To test locally and to exercise the comment search behavior:

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@
 
 	The comment search is performed using exponential backoff and can be tuned
 	with the following constants:
-    - initialInterval, randomizationFactor, multiplier, maxInterval, maxElapsedTime
+	- initialInterval, randomizationFactor, multiplier, maxInterval, maxElapsedTime
 	- more infor can be found in the `exponential.go`
 		- https://github.com/cenkalti/backoff/blob/a83af7fa09801a4a887cfe7c8472c12c76e8a468/exponential.go
 

--- a/main.go
+++ b/main.go
@@ -274,9 +274,9 @@ func main() {
 	} else {
 		foundComment := waitPlan(org, repo, pr)
 		atlantisPath = strings.Split(foundComment, "`")[1]
-		//approvePr(org, repo, pr)
+		approvePr(org, repo, pr)
 		//time.Sleep(timeOut) // TODO shouldn't really need this maybe take out.
-		//runApply(org, repo, pr, atlantisPath)
+		runApply(org, repo, pr, atlantisPath)
 		waitApply(org, repo, pr)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -30,9 +30,8 @@ const (
 	randomizationFactor = 0.5
 	multiplier          = 3
 	// Lower maxInterval increases the retry frequency, scoped to maxElapsedTime
-	//maxInterval     = 10 * time.Second
+	maxInterval = 10 * time.Second
 	//maxElapsedTime  = 15 * time.Minute
-	maxInterval     = 1 * time.Second
 	maxElapsedTime  = 7 * time.Minute
 	blinkGitHubUser = "blinkhealthgithub"
 
@@ -42,7 +41,7 @@ const (
 	 * recent one.
 	 */
 	acceptablePlanElapsedTolerance  = 65  //seconds
-	acceptableApplyElapsedTolerance = 120 //seconds
+	acceptableApplyElapsedTolerance = 300 //seconds
 	planComment                     = "Ran Plan for dir"
 	planError                       = "Plan Error"
 	applyComment                    = "Ran Apply for dir"


### PR DESCRIPTION
# Changes include:
 - add doc strings that were much needed
 - format the code (sorry) for the busy PR it creates
 - compute delta between comment searches using `backoff` and log it.
 - add separate tolerances for searching for `plan` vs `apply` as `atlantis apply` takes longer.
 - tune the exponential backoff so that it does not DDoS github, yet provides frequent grooming comments on the PR

---

# Testing

## Execution using this PR - where it shows `redis` (longest exection time) succeeding

<img width="788" alt="Screenshot 2023-10-03 at 12 44 07 PM" src="https://github.com/blinkhealth/atlantis-gh-action/assets/94632280/049ef164-603c-483f-b85f-9145d4e123a5">

---

<details><summary>Local example of execution</summary>

```
./atlantis-gh-action 26
PROCESSING PR blinkhealth/satyen-test-gh-action-1/pull/26
Retrieving comments... for next 30m0s
Atlantis must comment with ['Ran Plan for dir'] within [65s]

Looking for [Ran Plan for dir] elapsed (since start)[0.000s] -- (since last check)[0.000s]
Result found for [Ran Plan for dir] user: [blinkhealthgithub] PR created [2023-10-03 07:56:05 +0000 UTC] comment created [2023-10-03 07:56:32 +0000 UTC] time delta [27]
returning first line:[Ran Plan for dir: `provisioning/live/staging/aws/ec-redis` workspace: `provisioning_live_staging_aws_ec-redis`]; comment created: [2023-10-03 07:56:32 +0000 UTC]
Retrieving comments... for next 30m0s
Atlantis must comment with ['Ran Apply for dir'] within [15s]
Looking for [Ran Apply for dir] elapsed (since start)[0.000s] -- (since last check)[0.000s]
Looking for [Ran Apply for dir] elapsed (since start)[2.741s] -- (since last check)[2.741s]
Looking for [Ran Apply for dir] elapsed (since start)[9.382s] -- (since last check)[6.641s]
Looking for [Ran Apply for dir] elapsed (since start)[27.162s] -- (since last check)[17.780s]
Looking for [Ran Apply for dir] elapsed (since start)[83.093s] -- (since last check)[55.931s]
Looking for [Ran Apply for dir] elapsed (since start)[142.019s] -- (since last check)[58.926s]
Looking for [Ran Apply for dir] elapsed (since start)[202.717s] -- (since last check)[60.698s]
Looking for [Ran Apply for dir] elapsed (since start)[260.687s] -- (since last check)[57.970s]
Looking for [Ran Apply for dir] elapsed (since start)[319.411s] -- (since last check)[58.725s]
Looking for [Ran Apply for dir] elapsed (since start)[382.053s] -- (since last check)[62.642s]
Looking for [Ran Apply for dir] elapsed (since start)[445.215s] -- (since last check)[63.161s]
Looking for [Ran Apply for dir] elapsed (since start)[505.094s] -- (since last check)[59.879s]
Looking for [Ran Apply for dir] elapsed (since start)[566.074s] -- (since last check)[60.980s]
```





---




